### PR TITLE
Fix icon name in zhuyin.conf

### DIFF
--- a/src/zhuyin.conf.in
+++ b/src/zhuyin.conf.in
@@ -1,6 +1,6 @@
 [InputMethod]
 Name=Bopomofo
-Icon=fcitx-bopomofo
+Icon=fcitx-zhuyin
 Label=ㄓ
 LangCode=zh_TW
 Addon=zhuyin


### PR DESCRIPTION
Icon name mismatch with `data/CMakeLists.txt`