### PR TITLE
Adding missing headers

### DIFF
--- a/src/zhuyinsection.cpp
+++ b/src/zhuyinsection.cpp
@@ -7,6 +7,7 @@
 #include "zhuyinsection.h"
 #include "zhuyinbuffer.h"
 #include "zhuyincandidate.h"
+#include <limits>
 #include <fcitx-utils/utf8.h>
 
 namespace fcitx {


### PR DESCRIPTION
Similar to https://github.com/fcitx/fcitx5/pull/166 , `limits` must be explicitly included when building with GCC 11 prerelease.